### PR TITLE
Added a shortcode for displaying color preview

### DIFF
--- a/layouts/shortcodes/colors.html
+++ b/layouts/shortcodes/colors.html
@@ -1,0 +1,6 @@
+<span style="background-color:{{ .Get 0 }};
+             display: inline-block;
+             width: 70px;
+             height: 40px;
+             margin: 0 5px 0 5px;">
+</span>


### PR DESCRIPTION
Usage {{% colors "#F39C12" %}} - Will display a small box with the corresponding color. Useful for theme documentations.
