### PR TITLE
info about web.xml

### DIFF
--- a/content/docs/seed/manual/rest.md
+++ b/content/docs/seed/manual/rest.md
@@ -142,31 +142,32 @@ Testing REST resources can be done in a real Web environment by using [Seed Web 
 Consider this example:
 
     public class ProductsResourceIT extends AbstractSeedWebIT {
-    
+
+        @ArquillianResource
+        private URL baseURL;
+
         @Deployment
         public static WebArchive createDeployment() {
-            return ShrinkWrap.create(WebArchive.class).setWebXML("WEB-INF/web.xml");
+            return ShrinkWrap.create(WebArchive.class);
         }
     
         @RunAsClient
         @Test
-        public void testCreate(@ArquillianResource URL baseURL) throws JSONException {
+        public void testCreate() throws JSONException {
             JSONObject obj = new JSONObject();
             obj.put("summary", "The world's highest resolution notebook");
             obj.put("categoryId", 1);
             obj.put("designation", "macbook pro");
             obj.put("picture", "mypictureurl");
             obj.put("price", 200.0);
-    
-            //assert response code
+
             String response = expect().statusCode(201).given()
                     .header("Accept", "application/json")
                     .header("Content-Type", "application/json")
                     .body(obj.toString())
                     .post(baseURL.toString() + "rest/products/")
                     .asString();
-    
-            // assert body
+
             JSONAssert.assertEquals(obj, new JSONObject(response), false);
         }
         

--- a/content/docs/seed/manual/web.md
+++ b/content/docs/seed/manual/web.md
@@ -29,7 +29,9 @@ static-resources serving. To enable Web support in your project, add the `seed-w
 
 {{% callout info %}}
 When deploying a Seed application in a standalone Web container, the required minimum Servlet compliance level is 2.5 
-though some features require a Servlet 3.0 compliance level. All the features are available with the embedded Web server.
+though some features require a Servlet 3.0 compliance level. The presence of a `web.xml` file is only required for servlet 2.5.
+
+All the features are available with the embedded Web server.
 {{% /callout %}}
 
 # Security
@@ -459,7 +461,7 @@ client endpoints:
     
         @Deployment
         public static WebArchive createDeployment() {
-            return ShrinkWrap.create(WebArchive.class).setWebXML("WEB-INF/web.xml");
+            return ShrinkWrap.create(WebArchive.class);
         }
     
         @Test

--- a/content/posts/15-11-1-release-notes.md
+++ b/content/posts/15-11-1-release-notes.md
@@ -50,6 +50,18 @@ it add-ons. The main evolution of W20 is the upgrade to AngularJS 1.4.8 and Boot
 
 # New features
 
+## Servlet 3.1: no more web.xml
+
+Seed Web 2.2.0 comes with a support for [Servlet 3.1](https://java.net/downloads/servlet-spec/Final/servlet-3_1-final.pdf),
+but Servlet 2.5 is still supported. If your servlet container supports servlet 3+, **remove all your `web.xml` files and
+according tests configuration**.
+
+        @Deployment
+        public static WebArchive createDeployment() {
+            return ShrinkWrap.create(WebArchive.class)
+                       .setWebXML("WEB-INF/web.xml"); // TODO remove the web.xml configuration
+        }
+
 ## JAX-RS 2
 
 The version 2 of JAX-RS standard has been integrated in the Java framework through the Jersey 2 library. You can now


### PR DESCRIPTION
- Add a section about `web.xml` in the 15.11.1 release note
- Remove all the `web.xml` in the tests examples
- Precise in the web documentation that the `web.xml` are no more required
